### PR TITLE
get next stable release of flutter for circle

### DIFF
--- a/flutter/Dockerfile
+++ b/flutter/Dockerfile
@@ -1,6 +1,6 @@
 FROM circleci/android:api-28
 
-RUN curl https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_v1.12.13+hotfix.5-stable.tar.xz -o /tmp/flutter.tar.xz && \
+RUN curl https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_v1.12.13+hotfix.8-stable.tar.xz -o /tmp/flutter.tar.xz && \
   sudo tar -xvJ -C /opt -f /tmp/flutter.tar.xz && \
   sudo chown -R circleci:circleci /opt/flutter && \
   rm -f /tmp/flutter.tar.xz


### PR DESCRIPTION
Go to v1.12.13+hotfix.8-stable.tar to solve [this ticket](https://trello.com/c/XKJm1LEs/1014-allow-the-system-wide-back-gesture-to-follow-our-in-app-navigation)