### PR TITLE
upgrade to flutter 2.0.6

### DIFF
--- a/flutter/Dockerfile
+++ b/flutter/Dockerfile
@@ -1,6 +1,6 @@
 FROM circleci/android:api-29
 
-RUN curl https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_1.22.4-stable.tar.xz -o /tmp/flutter.tar.xz && \
+RUN curl https://storage.googleapis.com/flutter_infra/releases/stable/linux/flutter_linux_2.0.6-stable.tar.xz -o /tmp/flutter.tar.xz && \
   sudo tar -xvJ -C /opt -f /tmp/flutter.tar.xz && \
   sudo chown -R circleci:circleci /opt/flutter && \
   rm -f /tmp/flutter.tar.xz

--- a/flutter/publish_image.sh
+++ b/flutter/publish_image.sh
@@ -3,5 +3,5 @@
 OWNER='anvlco'
 REPOSITORY='circleci-dockerfiles'
 
-docker build -t "docker.pkg.github.com/$OWNER/$REPOSITORY/flutter:1.22.4" .
-docker push "docker.pkg.github.com/$OWNER/$REPOSITORY/flutter:1.22.4"
+docker build -t "docker.pkg.github.com/$OWNER/$REPOSITORY/flutter:2.0.6" .
+docker push "docker.pkg.github.com/$OWNER/$REPOSITORY/flutter:2.0.6"


### PR DESCRIPTION
This upgrades the containers used by circle ci to build Workforce to use Flutter 2.0.6