### PR TITLE
pin to version of android builds that use JDK 8

### DIFF
--- a/flutter/Dockerfile
+++ b/flutter/Dockerfile
@@ -1,4 +1,4 @@
-FROM circleci/android:api-30
+FROM circleci/android@sha256:b6646fdf7457f61825526e7bfce364d8e533da6ceb1cdb98e371e94348ecc834
 
 RUN sudo apt-get install -y locales
 RUN sudo dpkg-reconfigure locales


### PR DESCRIPTION
This pins the base android image to use JDK 8 instead of JDK11.  In the summer of 2020 circle [updated all android images to JDK 11](https://discuss.circleci.com/t/android-convenience-image-moving-to-java-v11-on-august-17th/36601).

[Flutter really wants to be using JDK 8 still](https://github.com/flutter/flutter/issues/68387).  In our case it is the connectivity plugin even at it's highest version needs JAXB.  [JAXB was marked deprecated in 9 and removed in JDK 11](https://jaxenter.com/jdk-11-java-ee-modules-140674.html).

The weakness with doing this is we don't get updates to the base image anymore.  Perhaps it's better to install JDK 8 in the docker file and set the java_home environment variable instead?